### PR TITLE
:wrench: Add support for tsconfig.json path env variable

### DIFF
--- a/packages/react-scripts/config/paths.js
+++ b/packages/react-scripts/config/paths.js
@@ -31,6 +31,11 @@ const publicUrlOrPath = getPublicUrlOrPath(
 
 const buildPath = process.env.BUILD_PATH || 'build';
 
+
+const tsConfigPath = process.env.TS_CONFIG_PATH || 'tsconfig.json';
+
+
+
 const moduleFileExtensions = [
   'web.mjs',
   'mjs',
@@ -68,7 +73,7 @@ module.exports = {
   appIndexJs: resolveModule(resolveApp, 'src/index'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
-  appTsConfig: resolveApp('tsconfig.json'),
+  appTsConfig: resolveApp(tsConfigPath),
   appJsConfig: resolveApp('jsconfig.json'),
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveModule(resolveApp, 'src/setupTests'),
@@ -93,7 +98,7 @@ module.exports = {
   appIndexJs: resolveModule(resolveApp, 'src/index'),
   appPackageJson: resolveApp('package.json'),
   appSrc: resolveApp('src'),
-  appTsConfig: resolveApp('tsconfig.json'),
+  appTsConfig: resolveApp(tsConfigPath),
   appJsConfig: resolveApp('jsconfig.json'),
   yarnLockFile: resolveApp('yarn.lock'),
   testsSetup: resolveModule(resolveApp, 'src/setupTests'),
@@ -131,7 +136,7 @@ if (
     appIndexJs: resolveModule(resolveOwn, `${templatePath}/src/index`),
     appPackageJson: resolveOwn('package.json'),
     appSrc: resolveOwn(`${templatePath}/src`),
-    appTsConfig: resolveOwn(`${templatePath}/tsconfig.json`),
+    appTsConfig: resolveOwn(`${templatePath}/${tsConfigPath}`),
     appJsConfig: resolveOwn(`${templatePath}/jsconfig.json`),
     yarnLockFile: resolveOwn(`${templatePath}/yarn.lock`),
     testsSetup: resolveModule(resolveOwn, `${templatePath}/src/setupTests`),

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -720,6 +720,7 @@ module.exports = function (webpackEnv) {
         new ForkTsCheckerWebpackPlugin({
           async: isEnvDevelopment,
           typescript: {
+            configFile: paths.appTsConfig,
             typescriptPath: resolve.sync('typescript', {
               basedir: paths.appNodeModules,
             }),


### PR DESCRIPTION
This is a follow-on from https://github.com/SenecaLabs/senecaWeb/pull/16555

This should let us add `TS_CONFIG_PATH='./path'` to allow multiple `tsconfig.json` files, which in turn will address the unit test intellisense issues.

We could just eject from CRA, but I think that will add a lot of noise when we come to migration and do more harm than good. I ran into issues with both `react-app-rewired` and CRACO when trying to do this, and given it's such a small change + the fact that CRA will likely see no further updates, it seems the most sensible option.

Will probably need some extra config to publish this though - not sure if we want to do this via verdaccio or otherwise?